### PR TITLE
Add several admin pages, mostly informational.

### DIFF
--- a/components/ImporterList.vue
+++ b/components/ImporterList.vue
@@ -1,0 +1,28 @@
+<template>
+  <div>
+    <v-container>
+      <v-row v-for="importer in importers" :key="importer.id">
+        <v-col>
+          <LazyHydrate when-visible>
+            <ImporterView :importer="importer"></ImporterView>
+          </LazyHydrate>
+        </v-col>
+      </v-row>
+    </v-container>
+  </div>
+</template>
+
+<script>
+export default {
+  components: {
+    ImporterView: () => import('@/components/ImporterView'),
+    LazyHydrate: () => import('vue-lazy-hydration')
+  },
+  props: {
+    importers: {
+      type: Array,
+      required: true
+    }
+  }
+}
+</script>

--- a/components/ImporterView.vue
+++ b/components/ImporterView.vue
@@ -1,0 +1,98 @@
+<template>
+  <div>
+    <v-card tile class="mx-auto overflow-hidden" elevation="3">
+      <v-row class="px-3">
+        <v-col cols="10">
+          <v-card-title class="align-start">
+            <div>
+              <span class="headline">Importer {{ importer.id }} ({{ importer.url }})</span>
+            </div>
+          </v-card-title>
+          <v-card-text>
+            <table>
+              <tr>
+                <td>Admin Status</td>
+                <td>{{ importer.admin_status }} ({{ this.$moment.utc(importer.admin_status_time).fromNow() }})</td>
+              </tr>
+              <tr>
+                <td>Status</td>
+                <td>{{ importer.status }} ({{ this.$moment.utc(importer.status_time).fromNow() }})</td>
+              </tr>
+              <tr>
+                <td>Max Tasks</td><td>{{ importer.max_tasks }}</td>
+              </tr>
+              <tr>
+                <td>Scheduled Tasks</td><td>{{ importer.scheduled.length }}</td>
+              </tr>
+            </table>
+
+            <v-data-table v-if="importer.scheduled.length"
+              :headers="scheduled_headers"
+              :items="scheduled_items"
+              :items-per-page="100">
+              <template v-slot:item.schedule_time="{ item }">
+                {{ $moment.utc(item.schedule_time).fromNow() }}
+              </template>
+            </v-data-table>
+          </v-card-text>
+        </v-col>
+      </v-row>
+      <v-card-actions>
+        <v-btn v-if="importer.admin_status === 'enabled'" text @click="disable()">
+          Disable
+        </v-btn>
+        <v-btn v-if="importer.admin_status === 'disabled'" text @click="enable()">
+          Enable
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+export default {
+  props: {
+    importer: {
+      type: Object,
+      required: true
+    }
+  },
+  data() {
+    return {
+      scheduled_headers: [
+        {
+          text: "Scheduled At",
+          align: "start",
+          sortable: true,
+          value: "schedule_time"
+        },
+        { text: "Import ID", value: "artifact_import_id" },
+        //{ text: "URL", value: "artifact_import.url" },
+        { text: "Owner", value: "artifact_import.owner.person.email" },
+        { text: "Status", value: "artifact_import.status" },
+        { text: "Phase", value: "artifact_import.phase" },
+        { text: "Artifact ID", value: "artifact_import.artifact_id" }
+      ],
+      scheduled_items: this.importer ? this.importer.scheduled : []
+    }
+  },
+  methods: {
+    async disable() {
+      let response = await this.$importerEndpoint.put(
+        this.importer.id, { admin_status: "disabled" })
+    },
+    async enable() {
+      let response = await this.$importerEndpoint.put(
+        this.importer.id, { admin_status: "enabled" })
+    }
+  }
+}
+</script>
+
+<style scoped>
+.v-card__title {
+  word-break: normal;
+}
+</style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -30,6 +30,28 @@
         </v-list-item>
       </v-list>
       <v-divider></v-divider>
+      <v-list v-if="adminItems.length">
+        <v-list-item
+          v-for="(item, i) in adminItems"
+          :key="`main${i}`"
+          :to="item.to"
+          router
+          exact
+        >
+          <v-list-item-action>
+            <v-tooltip right>
+              <template v-slot:activator="{ on, attrs }">
+                <v-icon v-on="on">{{ item.icon }}</v-icon>
+              </template>
+              <span>{{ item.title }}</span>
+            </v-tooltip>
+          </v-list-item-action>
+          <v-list-item-content>
+            <v-list-item-title v-text="item.title" />
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+      <v-divider v-if="adminItems.length"></v-divider>
       <v-list>
         <v-list-item
           v-for="(item, i) in footerItems"
@@ -59,6 +81,12 @@
       <v-toolbar-title v-text="title" />
       <v-spacer />
       <span v-if="$auth.loggedIn" class="mr-2" v-text="$auth.user.name"></span>
+      <v-btn v-if="$auth.loggedIn && this.user_can_admin && !this.user_is_admin" icon @click="setAdmin(true)">
+        <v-icon style="color: green">mdi-alpha-a-circle</v-icon>
+      </v-btn>
+      <v-btn v-else-if="$auth.loggedIn && this.user_can_admin && this.user_is_admin" icon @click="setAdmin(false)">
+        <v-icon style="color: red">mdi-alpha-a-circle</v-icon>
+      </v-btn>
       <v-btn v-if="$auth.loggedIn" class="primary" @click="logout()"
         >Logout</v-btn
       >
@@ -103,7 +131,9 @@ export default {
   },
   computed: {
     ...mapState({
-      userid: state => state.user.userid
+      userid: state => state.user.userid,
+      user_is_admin: state => state.user.user_is_admin,
+      user_can_admin: state => state.user.user_can_admin
     }),
     items() {
       let items = [
@@ -132,6 +162,37 @@ export default {
       }
       return items
     },
+    adminItems() {
+      let adminItems = []
+      if (this.$auth.loggedIn && this.user_is_admin) {
+        adminItems.push({
+          icon: 'mdi-wrench',
+          title: 'Artifacts',
+          to: '/admin/artifacts'
+        })
+        adminItems.push({
+          icon: 'mdi-wrench',
+          title: 'Artifact Imports',
+          to: '/admin/imports'
+        })
+        adminItems.push({
+          icon: 'mdi-wrench',
+          title: 'Users',
+          to: '/admin/users'
+        })
+        adminItems.push({
+          icon: 'mdi-wrench',
+          title: 'Login Sessions',
+          to: '/admin/sessions'
+        })
+        adminItems.push({
+          icon: 'mdi-wrench',
+          title: 'Importer Status',
+          to: '/admin/importers'
+        })
+      }
+      return adminItems
+    },
     footerItems() {
       let footerItems = [
         {
@@ -153,8 +214,27 @@ export default {
       if (confirm('Log out of SEARCCH?')) {
         console.log('Logging out')
         this.$store.commit('user/LOGOUT')
+        this.$store.commit('system/LOGOUT')
         this.$auth.logout()
       }
+    },
+    async setAdmin(mode) {
+      console.log('Setting admin mode', mode)
+      this.$loginEndpoint
+        .put({ is_admin: mode })
+        .then(response => {
+          this.$store.commit('user/SET_USER_IS_ADMIN', mode)
+          if (!mode) {
+            this.$store.commit('user/ADMIN_OFF')
+            this.$store.commit('system/ADMIN_OFF')
+            if (this.$route.name.startsWith("admin")) {
+              this.$router.push("/")
+            }
+          }
+        })
+        .catch(error => {
+          console.log('Failed to set admin mode', mode, error)
+        })
     }
   }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -67,7 +67,8 @@ export default {
     '~/plugins/base',
     '~/plugins/chartist',
     '~/plugins/components',
-    '~/plugins/sanitize'
+    '~/plugins/sanitize',
+    '~/plugins/moment'
   ],
   /*
    ** Nuxt.js dev-modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -13244,6 +13244,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -17896,6 +17901,14 @@
       "integrity": "sha512-XEeZUmlVeODclAjCNpWDnjgw+t3WA6gdzs6ENoIAgwO1J1d5p1tezDhtteLUFwcaQaTtayRrsx7GL6oXp/m2Jw==",
       "requires": {
         "deepmerge": "^4.2.2"
+      }
+    },
+    "vue-moment": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vue-moment/-/vue-moment-4.1.0.tgz",
+      "integrity": "sha512-Gzisqpg82ItlrUyiD9d0Kfru+JorW2o4mQOH06lEDZNgxci0tv/fua1Hl0bo4DozDV2JK1r52Atn/8QVCu8qQw==",
+      "requires": {
+        "moment": "^2.19.2"
       }
     },
     "vue-no-ssr": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "vue-chartist": "^2.3.1",
     "vue-lazy-hydration": "^2.0.0-beta.4",
     "vue-markdown": "^2.2.4",
+    "vue-moment": "^4.1.0",
     "vue-sanitize": "^0.2.1",
     "vue2-filters": "^0.11.1"
   },

--- a/pages/admin/artifacts.vue
+++ b/pages/admin/artifacts.vue
@@ -1,0 +1,201 @@
+<template>
+  <span>
+    <v-layout column justify-left align-top>
+      <v-row class="ml-1 mb-2">
+        <h1>Artifacts</h1>
+      </v-row>
+      <v-divider></v-divider><br />
+      <v-row align="center">
+        <v-col cols="1">
+          <h3>Filters:</h3>
+        </v-col>
+        <v-col cols="1">
+          <v-subheader>
+            Type
+          </v-subheader>
+        </v-col>
+        <v-col cols="2">
+          <v-select
+            v-model="type_select"
+            label="Type"
+            :items="type_items"
+            single-line
+            @change="updateArtifacts()"
+          ></v-select>
+        </v-col>
+        <v-col cols="1">
+          <v-subheader>
+            Published
+          </v-subheader>
+        </v-col>
+        <v-col cols="1">
+          <v-checkbox
+            v-model="published"
+            @change="updateArtifacts()"
+          ></v-checkbox>
+        </v-col>
+        <v-col cols="2">
+          <v-text-field
+            v-model="owner_filter"
+            hint="Case-insensitive substring of user name or email"
+            label="Owner"
+            @change="updateArtifacts()"
+          ></v-text-field>
+        </v-col>
+        <v-col cols="2"></v-col>
+        <v-col cols="1">
+          <h3>Refresh:</h3>
+        </v-col>
+        <v-col cols="1">
+          <v-btn icon @click="updateArtifacts()">
+            <v-icon>mdi-refresh</v-icon>
+          </v-btn>
+        </v-col>
+      </v-row>
+      <v-divider></v-divider><br />
+      <v-data-table
+        :headers="headers"
+        :items="items"
+        :loading="loading"
+        :options.sync="options"
+        :server-items-length="total"
+        :footer-props="{'items-per-page-options':[10, 20, 50, 100, -1]}">
+        <template #item.id="{ item }">
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on }">
+              <a v-if="item.id" :href="`/artifact/${item.id}`">
+                <v-icon v-on="on">mdi-database</v-icon>
+              </a>
+            </template>
+            <span>View</span>
+          </v-tooltip>
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on }">
+              <a v-if="!item.publication" :href="`/artifact/${item.id}?edit=true`">
+                <v-icon v-on="on">mdi-database-edit</v-icon>
+              </a>
+            </template>
+            <span>Edit</span>
+          </v-tooltip>
+        </template>
+        <template v-slot:item.ctime="{ item }">
+          {{ $moment.utc(item.ctime).fromNow() }}
+        </template>
+        <template v-slot:item.mtime="{ item }">
+          {{ item.mtime ? $moment.utc(item.mtime).fromNow() : "" }}
+        </template>
+        <template #item.url="{ item }">
+          <a v-if="item.url" :href="`${item.url}`">{{ ellipsize(item.url,32) }}</a>
+        </template>
+        <template #item.publication="{ item }">
+          <v-icon v-if="item.publication">mdi-check</v-icon>
+        </template>
+        <template #item.owner.person="{ item }">
+          {{ item.owner.person.email }}{{ item.owner.person.name ? " (" + item.owner.person.name + ")" : "" }}
+        </template>
+      </v-data-table>
+    </div>
+    </v-layout>
+  </span>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+export default {
+  data() {
+    return {
+      loadingMessage: 'Loading imports...',
+      timeoutID: null,
+      type_select: "",
+      type_items: [
+          "", "dataset", "executable", "methodology", "metrics",
+          "priorwork", "publication", "hypothesis", "code", "domain",
+          "supportinginfo" ],
+      published: false,
+      owner_filter: "",
+      headers: [
+        { text: "Artifact", value: "id", align: "start", sortable: true },
+        { text: "Created", sortable: true, align: "start", value: "ctime", sortable: true },
+        { text: "Modified", sortable: true, align: "start", value: "mtime", sortable: true },
+        { text: "Type", value: "type", sortable: true },
+        { text: "URL", value: "url", sortable: true },
+        { text: "Title", value: "title", sortable: true },
+        { text: "Published", value: "publication", sortable: true },
+        { text: "Owner", value: "owner.person", sortable: false },
+        //{ text: "Owner Email", value: "owner.person.email", sortable: false },
+      ],
+      loading: true,
+      options: {
+        itemsPerPage: 10,
+        page: 1,
+        sortDesc: [true]
+      },
+    }
+  },
+  async mounted() {
+    this.$store.dispatch('user/fetchUser')
+    this.loadingMessage = 'Loading artifacts...'
+    this.updateArtifacts()
+    this.timeoutID = setTimeout(() => {
+      this.loadingMessage = 'No artifacts found'
+    }, 5000)
+  },
+  computed: {
+    ...mapState({
+      user_is_admin: state => state.user.user_is_admin,
+      items: state => state.system.artifacts.artifacts,
+      //page: state => state.system.artifacts.page,
+      //pages: state => state.system.artifacts.pages,
+      total: state => state.system.artifacts.total
+    }),
+  },
+  methods: {
+    ellipsize(s,l) {
+      if (s.length > l)
+        return s.substring(0, l) + "...";
+      else
+        return s;
+    },
+    updateArtifacts() {
+      if (this.user_is_admin) {
+        this.loading = true
+        var payload = {
+          page: this.options.page, items_per_page: this.options.itemsPerPage,
+          sort: this.options.sortBy, sort_desc: this.options.sortDesc[0] === true ? 1 : 0,
+          allusers: 1, short_view_include: "owner,publication"
+        }
+        if (this.type_select)
+          payload["type"] = this.type_select
+        if (this.published)
+          payload["published"] = 1
+        if (this.owner_filter)
+          payload["owner"] = this.owner_filter
+        this.$store.dispatch('system/fetchArtifacts', payload)
+      }
+      clearTimeout(this.timeoutID)
+    }
+  },
+  watch: {
+    user_is_admin() {
+      // had to make this because on refresh, user_is_admin doesn't update until after the mounted has already run,
+      // but mounted needs to run when switching pages where the user_is_admin doesn't update
+      console.log("watch updateArtifacts")
+      this.updateArtifacts()
+    },
+    items() {
+      this.loading = false
+    },
+    options: {
+      handler () {
+        this.updateArtifacts()
+      },
+      deep: true,
+    }
+  },
+  beforeRouteLeave(to, from, next) {
+    clearTimeout(this.timeoutID)
+    next()
+  }
+}
+</script>

--- a/pages/admin/importers.vue
+++ b/pages/admin/importers.vue
@@ -1,0 +1,72 @@
+<template>
+  <span>
+    <v-layout column justify-left align-top>
+      <v-row class="ml-1 mb-2">
+        <h1>Importers</h1>
+      </v-row>
+      <v-divider></v-divider><br />
+      <ImporterList v-if="importers && importers.length" :importers="importers"></ImporterList>
+      <div v-else>{{ loadingMessage }}</div>
+    </v-layout>
+  </span>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+export default {
+  components: {
+    ImporterList: () => import('@/components/ImporterList')
+  },
+  data() {
+    return {
+      loadingMessage: 'Loading importers...',
+      pollingID: null,
+      timeoutID: null
+    }
+  },
+  async mounted() {
+    this.$store.dispatch('user/fetchUser')
+    this.loadingMessage = 'Loading importers...'
+    this.updateImporters()
+    this.timeoutID = setTimeout(() => {
+      this.loadingMessage = 'No importers found'
+      clearInterval(this.pollingID)
+    }, 5000)
+    this.pollingID = setInterval(
+      function() {
+        this.updateImporters()
+      }.bind(this),
+      5000
+    )
+  },
+  computed: {
+    ...mapState({
+      user_is_admin: state => state.user.user_is_admin,
+      importers: state => state.system.importers
+    })
+  },
+  methods: {
+    updateImporters() {
+      if (this.user_is_admin) {
+        this.$store.dispatch('system/fetchImporters')
+      }
+      if (!this.importers || !this.importers.length) {
+        //clearInterval(this.pollingID)
+      }
+    }
+  },
+  watch: {
+    user_is_admin() {
+      // had to make this because on refresh, user_is_admin doesn't update until after the mounted has already run,
+      // but mounted needs to run when switching pages where the user_is_admin doesn't update
+      this.updateImporters()
+    }
+  },
+  beforeRouteLeave(to, from, next) {
+    clearInterval(this.pollingID)
+    clearTimeout(this.timeoutID)
+    next()
+  }
+}
+</script>

--- a/pages/admin/imports.vue
+++ b/pages/admin/imports.vue
@@ -1,0 +1,179 @@
+<template>
+  <span>
+    <v-layout column justify-left align-top>
+      <v-row class="ml-1 mb-2">
+        <h1>Artifact Imports</h1>
+      </v-row>
+      <v-divider></v-divider><br />
+      <v-row align="center">
+        <v-col cols="1">
+          <h3>Filters:</h3>
+        </v-col>
+        <v-col cols="1">
+          <v-subheader>
+            Status
+          </v-subheader>
+        </v-col>
+        <v-col cols="2">
+          <v-select
+            v-model="status_select"
+            label="Status"
+            :items="status_items"
+            single-line
+            @change="updateImports()"
+          ></v-select>
+        </v-col>
+        <v-col cols="1">
+          <v-subheader>
+            Archived
+          </v-subheader>
+        </v-col>
+        <v-col cols="1">
+          <v-checkbox
+            v-model="archived"
+            @change="updateImports()"
+          ></v-checkbox>
+        </v-col>
+        <v-col cols="2">
+          <v-text-field
+            v-model="owner_filter"
+            hint="Case-insensitive substring of user name or email"
+            label="Owner"
+            @change="updateImports()"
+          ></v-text-field>
+        </v-col>
+        <v-col cols="2"></v-col>
+        <v-col cols="1">
+          <h3>Refresh:</h3>
+        </v-col>
+        <v-col cols="1">
+          <v-btn icon @click="updateImports()"> <!-- :right="true" :absolute="true">-->
+            <v-icon>mdi-refresh</v-icon>
+          </v-btn>
+        </v-col>
+      </v-row>
+      <v-divider></v-divider><br />
+      <v-data-table
+        :headers="headers"
+        :items="items"
+        :loading="loading"
+        :options.sync="options"
+        :server-items-length="total"
+        :footer-props="{'items-per-page-options':[10, 20, 50, 100, -1]}">
+        <template #item.id="{ item }">
+          <a v-if="item.id" :href="`/artifact/import/${item.id}`">View</a>
+        </template>
+        <template v-slot:item.ctime="{ item }">
+          {{ $moment.utc(item.ctime).fromNow() }}
+        </template>
+        <template #item.url="{ item }">
+          <a v-if="item.url" :href="`${item.url}`">{{ ellipsize(item.url,32) }}</a>
+        </template>
+        <template #item.artifact_id="{ item }">
+          <a v-if="item.artifact_id" :href="`/artifact/${item.artifact_id}`">View</a>
+        </template>
+        <template #item.owner.person="{ item }">
+          {{ item.owner.person.email }}{{ item.owner.person.name ? " (" + item.owner.person.name + ")" : "" }}
+        </template>
+      </v-data-table>
+    </div>
+    </v-layout>
+  </span>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+export default {
+  data() {
+    return {
+      loadingMessage: 'Loading imports...',
+      timeoutID: null,
+      status_select: "",
+      status_items: [ "", "pending", "scheduled", "running", "completed", "failed" ],
+      archived: false,
+      owner_filter: "",
+      headers: [
+        { text: "Import", value: "id", align: "start", sortable: true },
+        { text: "Created", sortable: true, align: "start", value: "ctime", sortable: true },
+        { text: "Status", value: "status", sortable: true },
+        //{ text: "Phase", value: "phase", sortable: true },
+        { text: "URL", value: "url", sortable: true },
+        { text: "Owner", value: "owner.person", sortable: false },
+        //{ text: "Owner Email", value: "owner.person.email", sortable: false },
+        { text: "Artifact", value: "artifact_id", sortable: true },
+      ],
+      loading: true,
+      options: {
+        itemsPerPage: 10,
+        page: 1,
+        sortDesc: [true]
+      },
+    }
+  },
+  async mounted() {
+    this.$store.dispatch('user/fetchUser')
+    this.loadingMessage = 'Loading imports...'
+    this.updateImports()
+    this.timeoutID = setTimeout(() => {
+      this.loadingMessage = 'No imports found'
+    }, 5000)
+  },
+  computed: {
+    ...mapState({
+      user_is_admin: state => state.user.user_is_admin,
+      items: state => state.system.artifact_imports.artifact_imports,
+      //page: state => state.system.artifact_imports.page,
+      //pages: state => state.system.artifact_imports.pages,
+      total: state => state.system.artifact_imports.total
+    }),
+  },
+  methods: {
+    ellipsize(s,l) {
+      if (s.length > l)
+        return s.substring(0, l) + "...";
+      else
+        return s;
+    },
+    updateImports() {
+      if (this.user_is_admin) {
+        this.loading = true
+        var payload = {
+          page: this.options.page, items_per_page: this.options.itemsPerPage,
+          sort: this.options.sortBy, sort_desc: this.options.sortDesc[0] === true ? 1 : 0,
+          allusers: 1
+        }
+        if (this.status_select)
+          payload["status"] = this.status_select
+        if (this.archived)
+          payload["archived"] = 1
+        if (this.owner_filter)
+          payload["owner"] = this.owner_filter
+        this.$store.dispatch('system/fetchArtifactImports', payload)
+      }
+      clearTimeout(this.timeoutID)
+    }
+  },
+  watch: {
+    user_is_admin() {
+      // had to make this because on refresh, user_is_admin doesn't update until after the mounted has already run,
+      // but mounted needs to run when switching pages where the user_is_admin doesn't update
+      console.log("watch updateImports")
+      this.updateImports()
+    },
+    items() {
+      this.loading = false
+    },
+    options: {
+      handler () {
+        this.updateImports()
+      },
+      deep: true,
+    }
+  },
+  beforeRouteLeave(to, from, next) {
+    clearTimeout(this.timeoutID)
+    next()
+  }
+}
+</script>

--- a/pages/admin/sessions.vue
+++ b/pages/admin/sessions.vue
@@ -1,0 +1,174 @@
+<template>
+  <span>
+    <v-layout column justify-left align-top>
+      <v-row class="ml-1 mb-2">
+        <h1>Login Sessions</h1>
+      </v-row>
+      <v-divider></v-divider><br />
+      <v-row align="center">
+        <v-col cols="1">
+          <h3>Filters:</h3>
+        </v-col>
+        <v-col cols="1">
+          <v-subheader>
+            Is Admin
+          </v-subheader>
+        </v-col>
+        <v-col cols="1">
+          <v-checkbox
+            v-model="is_admin"
+            @change="updateSessions()"
+          ></v-checkbox>
+        </v-col>
+        <v-col cols="1">
+          <v-subheader>
+            Can Admin
+          </v-subheader>
+        </v-col>
+        <v-col cols="1">
+          <v-checkbox
+            v-model="can_admin"
+            @change="updateSessions()"
+          ></v-checkbox>
+        </v-col>
+        <v-col cols="2">
+          <v-text-field
+            v-model="owner_filter"
+            hint="Case-insensitive substring of user name or email"
+            label="Owner"
+            @change="updateSessions()"
+          ></v-text-field>
+        </v-col>
+        <v-col cols="2"></v-col>
+        <v-col cols="1">
+          <h3>Refresh:</h3>
+        </v-col>
+        <v-col cols="1">
+          <v-btn icon @click="updateSessions()">
+            <v-icon>mdi-refresh</v-icon>
+          </v-btn>
+        </v-col>
+      </v-row>
+      <v-divider></v-divider><br />
+      <v-data-table
+        :headers="headers"
+        :items="items"
+        :loading="loading"
+        :options.sync="options"
+        :server-items-length="total"
+        :footer-props="{'items-per-page-options':[10, 20, 50, 100, -1]}">
+        <template #item.user_id="{ item }">
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on }">
+              <a v-if="item.id" :href="`/profile/${item.id}`">
+                <v-icon v-on="on">mdi-account</v-icon>
+              </a>
+            </template>
+            <span>View User Profile</span>
+          </v-tooltip>
+        </template>
+        <template v-slot:item.expires_on="{ item }">
+          {{ $moment.utc(item.expires_on).fromNow() }}
+        </template>
+        <template #item.is_admin="{ item }">
+          <v-icon v-if="item.is_admin">mdi-check</v-icon>
+        </template>
+        <template #item.user.can_admin="{ item }">
+          <v-icon v-if="item.user.can_admin">mdi-check</v-icon>
+        </template>
+        <template #item.user="{ item }">
+          {{ item.user.person.email }}{{ item.user.person.name ? " (" + item.user.person.name + ")" : "" }}
+        </template>
+      </v-data-table>
+    </div>
+    </v-layout>
+  </span>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+export default {
+  data() {
+    return {
+      loadingMessage: 'Loading imports...',
+      timeoutID: null,
+      is_admin: false,
+      can_admin: false,
+      owner_filter: "",
+      headers: [
+        { text: "Session ID", value: "id", align: "start", sortable: true },
+        { text: "Expires", value: "expires_on", sortable: true },
+        { text: "User", value: "user" },
+        //{ text: "User ID", value: "user.id" },
+        { text: "Is Admin", value: "is_admin" },
+        { text: "Can Admin", value: "user.can_admin" },
+      ],
+      loading: true,
+      options: {
+        itemsPerPage: 10,
+        page: 1,
+        sortDesc: [true]
+      },
+    }
+  },
+  async mounted() {
+    this.$store.dispatch('user/fetchUser')
+    this.loadingMessage = 'Loading sessions...'
+    this.updateSessions()
+    this.timeoutID = setTimeout(() => {
+      this.loadingMessage = 'No sessions found'
+    }, 5000)
+  },
+  computed: {
+    ...mapState({
+      user_is_admin: state => state.user.user_is_admin,
+      items: state => state.system.sessions.sessions,
+      //page: state => state.system.sessions.page,
+      //pages: state => state.system.sessions.pages,
+      total: state => state.system.sessions.total
+    }),
+  },
+  methods: {
+    updateSessions() {
+      if (this.user_is_admin) {
+        this.loading = true
+        var payload = {
+          page: this.options.page, items_per_page: this.options.itemsPerPage,
+          sort: this.options.sortBy, sort_desc: this.options.sortDesc[0] === true ? 1 : 0,
+          allusers: 1
+        }
+        if (this.is_admin)
+          payload["is_admin"] = 1
+        if (this.can_admin)
+          payload["can_admin"] = 1
+        if (this.owner_filter)
+          payload["owner"] = this.owner_filter
+        this.$store.dispatch('system/fetchSessions', payload)
+      }
+      clearTimeout(this.timeoutID)
+    }
+  },
+  watch: {
+    user_is_admin() {
+      // had to make this because on refresh, user_is_admin doesn't update until after the mounted has already run,
+      // but mounted needs to run when switching pages where the user_is_admin doesn't update
+      console.log("watch updateSessions")
+      this.updateSessions()
+    },
+    items() {
+      this.loading = false
+    },
+    options: {
+      handler () {
+        this.updateSessions()
+      },
+      deep: true,
+    }
+  },
+  beforeRouteLeave(to, from, next) {
+    clearTimeout(this.timeoutID)
+    next()
+  }
+}
+</script>

--- a/pages/admin/users.vue
+++ b/pages/admin/users.vue
@@ -1,0 +1,149 @@
+<template>
+  <span>
+    <v-layout column justify-left align-top>
+      <v-row class="ml-1 mb-2">
+        <h1>Users</h1>
+      </v-row>
+      <v-divider></v-divider><br />
+      <v-row align="center">
+        <v-col cols="1">
+          <h3>Filters:</h3>
+        </v-col>
+        <v-col cols="1">
+          <v-subheader>
+            Can Admin
+          </v-subheader>
+        </v-col>
+        <v-col cols="1">
+          <v-checkbox
+            v-model="can_admin"
+            @change="updateUsers()"
+          ></v-checkbox>
+        </v-col>
+        <v-col cols="2">
+          <v-text-field
+            v-model="owner_filter"
+            hint="Case-insensitive substring of user name or email"
+            label="User"
+            @change="updateUsers()"
+          ></v-text-field>
+        </v-col>
+        <v-col cols="2"></v-col>
+        <v-col cols="1">
+          <h3>Refresh:</h3>
+        </v-col>
+        <v-col cols="1">
+          <v-btn icon @click="updateUsers()">
+            <v-icon>mdi-refresh</v-icon>
+          </v-btn>
+        </v-col>
+      </v-row>
+      <v-divider></v-divider><br />
+      <v-data-table
+        :headers="headers"
+        :items="items"
+        :loading="loading"
+        :options.sync="options"
+        :server-items-length="total"
+        :footer-props="{'items-per-page-options':[10, 20, 50, 100, -1]}">
+        <template #item.id="{ item }">
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on }">
+              <a v-if="item.id" :href="`/profile/${item.id}`">
+                <v-icon v-on="on">mdi-account</v-icon>
+              </a>
+            </template>
+            <span>View User Profile</span>
+          </v-tooltip>
+        </template>
+        <template #item.can_admin="{ item }">
+          <v-icon v-if="item.can_admin">mdi-check</v-icon>
+        </template>
+      </v-data-table>
+    </div>
+    </v-layout>
+  </span>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+export default {
+  data() {
+    return {
+      loadingMessage: 'Loading users...',
+      timeoutID: null,
+      can_admin: false,
+      owner_filter: "",
+      headers: [
+        { text: "User ID", value: "id", align: "start", sortable: true },
+        { text: "User Email", value: "person.email" },
+        { text: "User Name", value: "person.name" },
+        { text: "Can Admin", value: "can_admin" },
+      ],
+      loading: true,
+      options: {
+        itemsPerPage: 10,
+        page: 1,
+        sortDesc: [true]
+      },
+    }
+  },
+  async mounted() {
+    this.$store.dispatch('user/fetchUser')
+    this.loadingMessage = 'Loading users...'
+    this.updateUsers()
+    this.timeoutID = setTimeout(() => {
+      this.loadingMessage = 'No users found'
+    }, 5000)
+  },
+  computed: {
+    ...mapState({
+      user_is_admin: state => state.user.user_is_admin,
+      items: state => state.system.users.users,
+      //page: state => state.system.users.page,
+      //pages: state => state.system.users.pages,
+      total: state => state.system.users.total
+    }),
+  },
+  methods: {
+    updateUsers() {
+      if (this.user_is_admin) {
+        this.loading = true
+        var payload = {
+          page: this.options.page, items_per_page: this.options.itemsPerPage,
+          sort: this.options.sortBy, sort_desc: this.options.sortDesc[0] === true ? 1 : 0,
+          allusers: 1
+        }
+        if (this.can_admin)
+          payload["can_admin"] = 1
+        if (this.owner_filter)
+          payload["owner"] = this.owner_filter
+        this.$store.dispatch('system/fetchUsers', payload)
+      }
+      clearTimeout(this.timeoutID)
+    }
+  },
+  watch: {
+    user_is_admin() {
+      // had to make this because on refresh, user_is_admin doesn't update until after the mounted has already run,
+      // but mounted needs to run when switching pages where the user_is_admin doesn't update
+      console.log("watch updateUsers")
+      this.updateUsers()
+    },
+    items() {
+      this.loading = false
+    },
+    options: {
+      handler () {
+        this.updateUsers()
+      },
+      deep: true,
+    }
+  },
+  beforeRouteLeave(to, from, next) {
+    clearTimeout(this.timeoutID)
+    next()
+  }
+}
+</script>

--- a/pages/artifact/import/_id.vue
+++ b/pages/artifact/import/_id.vue
@@ -1,0 +1,34 @@
+<template>
+  <div>
+    <v-layout column justify-center align-center>
+      <v-flex xs12 sm8 md6>
+        <div class="text-center">
+          <logo />
+        </div>
+      </v-flex>
+    </v-layout>
+    <a @click="$router.go(-1)">Back</a>
+    <ArtifactImportView :artifact="artifact"></ArtifactImportView>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+export default {
+  components: {
+    Logo: () => import('@/components/Logo'),
+    ArtifactImportView: () => import('@/components/ArtifactImportView')
+  },
+  computed: {
+    ...mapState({
+      artifact: state => state.artifacts.import
+    })
+  },
+  mounted() {
+    this.$store.dispatch('artifacts/fetchImport', {
+      id: this.$route.params.id
+    })
+  }
+}
+</script>

--- a/plugins/auth.js
+++ b/plugins/auth.js
@@ -27,6 +27,8 @@ export default function({ $loginEndpoint, store, $auth }) {
           store.commit('user/SET_USER_TOKEN', payload.token)
           store.commit('user/SET_USER', response.person)
           store.commit('user/SET_USERID', response.userid)
+          store.commit('user/SET_USER_IS_ADMIN', response.is_admin)
+          store.commit('user/SET_USER_CAN_ADMIN', response.can_admin)
           store.dispatch('artifacts/fetchFavorites', response.userid)
         }
       })

--- a/plugins/moment.js
+++ b/plugins/moment.js
@@ -1,0 +1,3 @@
+import Vue from 'vue'
+
+Vue.use(require('vue-moment'))

--- a/plugins/repository.js
+++ b/plugins/repository.js
@@ -4,11 +4,14 @@ export default (ctx, inject) => {
   // And in the Vue instances (this.$repository in your components)
   const repositoryWithAxios = createRepository(ctx.$axios)
 
-  // artifact searching
+  // artifacts
   inject('artifactsEndpoint', repositoryWithAxios('kg/' + 'artifacts'))
 
   // artifact retrieval
   inject('artifactRecordEndpoint', repositoryWithAxios('kg/' + 'artifact'))
+
+  // artifact searching
+  inject('artifactSearchEndpoint', repositoryWithAxios('kg/' + 'artifact/search'))
 
   // imports array view/add API
   inject('importsEndpoint', repositoryWithAxios('kg/' + 'artifact/imports'))
@@ -49,6 +52,9 @@ export default (ctx, inject) => {
   // reviews modify API
   inject('reviewsEndpoint', repositoryWithAxios('kg/' + 'review'))
 
+  // users index API
+  inject('usersEndpoint', repositoryWithAxios('kg/' + 'users'))
+
   // user API
   inject('userEndpoint', repositoryWithAxios('kg/' + 'user'))
 
@@ -75,4 +81,13 @@ export default (ctx, inject) => {
 
   // dashboard API
   inject('dashboardEndpoint', repositoryWithAxios('kg/' + 'dashboard'))
+
+  // importers array view API
+  inject('importersEndpoint', repositoryWithAxios('kg/' + 'importers'))
+
+  // importer view/modify API
+  inject('importerEndpoint', repositoryWithAxios('kg/' + 'importer'))
+
+  // sessions index API
+  inject('sessionsEndpoint', repositoryWithAxios('kg/' + 'sessions'))
 }

--- a/store/artifacts.js
+++ b/store/artifacts.js
@@ -18,6 +18,7 @@ export const state = () => ({
   favorites: [],
   favoritesIDs: {},
   imports: [],
+  import: {},
   loading: false
 })
 
@@ -39,6 +40,9 @@ export const getters = {
   },
   imports: state => {
     return state.imports
+  },
+  import: state => {
+    return state.import
   },
   loading: state => {
     return state.loading
@@ -67,6 +71,9 @@ export const mutations = {
   SET_IMPORTS(state, imports) {
     state.imports = imports
   },
+  SET_IMPORT(state, import_) {
+    state.import = import_
+  },
   SET_LOADING(state, loading) {
     state.loading = loading
   }
@@ -76,7 +83,7 @@ export const actions = {
   async fetchArtifacts({ commit, state }, payload) {
     commit('SET_LOADING', true)
     commit('SET_SEARCH', payload.keywords)
-    let response = await this.$artifactsEndpoint.index({
+    let response = await this.$artifactSearchEndpoint.index({
       ...payload
     })
     if (typeof response !== 'undefined') {
@@ -115,6 +122,14 @@ export const actions = {
       if (response.artifact_imports) {
         commit('SET_IMPORTS', response.artifact_imports)
       }
+    }
+    commit('SET_LOADING', false)
+  },
+  async fetchImport({ commit, state }, payload) {
+    commit('SET_LOADING', true)
+    let response = await this.$importEndpoint.show(payload.id)
+    if (typeof response !== 'undefined') {
+      commit('SET_IMPORT', response)
     }
     commit('SET_LOADING', false)
   },

--- a/store/system.js
+++ b/store/system.js
@@ -1,0 +1,107 @@
+import Vue from 'vue'
+
+export const state = () => ({
+  artifacts: {},
+  artifact_imports: {},
+  users: {},
+  sessions: {},
+  importers: []
+})
+
+export const getters = {
+  artifacts: state => {
+    return state.artifacts
+  },
+  artifact_imports: state => {
+    return state.artifact_imports
+  },
+  users: state => {
+    return state.users
+  },
+  sessions: state => {
+    return state.sessions
+  },
+  importers: state => {
+    return state.importers
+  }
+}
+
+export const mutations = {
+  SET_ARTIFACTS(state, artifacts) {
+    state.artifacts = artifacts
+  },
+  SET_ARTIFACT_IMPORTS(state, artifact_imports) {
+    state.artifact_imports = artifact_imports
+  },
+  SET_USERS(state, users) {
+    state.users = users
+  },
+  SET_SESSIONS(state, sessions) {
+    state.sessions = sessions
+  },
+  SET_IMPORTERS(state, importers) {
+    state.importers = importers
+  },
+  LOGOUT(state) {
+    state.artifacts = {},
+    state.artifact_imports = {},
+    state.users = {},
+    state.sessions = {}
+    state.importers = []
+  },
+  ADMIN_OFF(state) {
+    state.artifacts = {},
+    state.artifact_imports = {},
+    state.users = {},
+    state.sessions = {}
+    state.importers = []
+  }
+}
+
+export const actions = {
+  async fetchArtifacts({ commit, state }, payload) {
+    let response = await this.$artifactsEndpoint.index({
+      ...payload
+    })
+    if (response) {
+      commit('SET_ARTIFACTS', response)
+      console.log("fetched artifacts (admin)")
+    }
+  },
+  async fetchArtifactImports({ commit, state }, payload) {
+    let response = await this.$importsEndpoint.index({
+      ...payload
+    })
+    if (response) {
+      commit('SET_ARTIFACT_IMPORTS', response)
+      console.log("fetched artifact_imports (admin)")
+    }
+  },
+  async fetchUsers({ commit, state }, payload) {
+    let response = await this.$usersEndpoint.index({
+      ...payload
+    })
+    if (response) {
+      commit('SET_USERS', response)
+      console.log("fetched users (admin)")
+    }
+  },
+  async fetchSessions({ commit, state }, payload) {
+    let response = await this.$sessionsEndpoint.index({
+      ...payload
+    })
+    if (response) {
+      commit('SET_SESSIONS', response)
+      console.log("fetched sessions (admin)")
+    }
+  },
+  async fetchImporters({ commit, state }, payload) {
+    let response = await this.$importersEndpoint.index({
+      ...payload
+    })
+    if (response.importers) {
+      commit('SET_IMPORTERS', response.importers)
+      console.log("fetched importers (admin)")
+    }
+  }
+}

--- a/store/user.js
+++ b/store/user.js
@@ -3,6 +3,8 @@ import Vue from 'vue'
 export const state = () => ({
   user: null,
   userid: null,
+  user_can_admin: false,
+  user_is_admin: false,
   organization: [],
   orgs: [],
   user_token: null,
@@ -27,6 +29,12 @@ export const getters = {
   },
   userid: state => {
     return state.userid
+  },
+  user_can_admin: state => {
+    return state.user_can_admin
+  },
+  user_is_admin: state => {
+    return state.user_is_admin
   },
   interests: state => {
     return state.interests
@@ -55,6 +63,12 @@ export const mutations = {
   SET_USERID(state, userid) {
     state.userid = userid
   },
+  SET_USER_IS_ADMIN(state, user_is_admin) {
+    state.user_is_admin = user_is_admin
+  },
+  SET_USER_CAN_ADMIN(state, user_can_admin) {
+    state.user_can_admin = user_can_admin
+  },
   SET_ORGS(state, orgs) {
     state.orgs = orgs
   },
@@ -68,6 +82,10 @@ export const mutations = {
     state.interests = null
     state.user_token = null
     state.userid = null
+    state.user_is_admin = false
+    state.user_can_admin = false
+  },
+  ADMIN_OFF(state) {
   }
 }
 
@@ -78,6 +96,8 @@ export const actions = {
     response = await this.$userEndpoint.index()
     commit('SET_USER', response.user.person)
     commit('SET_USERID', response.user.id)
+    commit('SET_USER_CAN_ADMIN', response.user.can_admin)
+    commit('SET_USER_IS_ADMIN', response.user.is_admin)
     commit('SET_USER_ORGS', response.user.affiliations)
   },
   async setUserToken({ commit }, user_token) {


### PR DESCRIPTION
Mostly additive, but the prior GET /artifacts endpoint moved to
GET /artifact/search -- it was returning many non-artifact pieces
of information.  It's still wrong, but the damage is at least localized,
and now GET /artifacts is CRUD-compliant.