### PR TITLE
added frontend support for sort results

### DIFF
--- a/components/SearchCard.vue
+++ b/components/SearchCard.vue
@@ -89,6 +89,7 @@
                   </template>
                 </v-select>
               </v-col>
+              
               <v-col cols="12">
                 <v-select
                   v-model="advanced.badge_ids"
@@ -129,6 +130,18 @@
                     {{ `${item.organization} ${item.title}` }}
                   </template>
                 </v-select>
+              </v-col>
+
+              <v-col cols="12" sm ="8">
+                <v-select label="Sort Results" :items="['None','date', 'views', 'rating']" @change = "showOptions">
+                </v-select>
+              </v-col>
+              
+              <v-col cols="12" sm="4">
+                <v-radio-group v-model="row" v-if = "sortEnabled" row @change = "setSortType">
+                  <v-radio label="Ascending" value="asc"></v-radio>
+                  <v-radio label="Descending" value="desc"></v-radio>
+                </v-radio-group>
               </v-col>
               <v-col cols="12">
                 <v-text-field
@@ -214,6 +227,9 @@ export default {
       search: '',
       author: '',
       owner: '',
+      sort_type: '',
+      sort_criteria : '',
+      sortEnabled : false,
       organization: '',
       searchMessage: '',
       searchInterval: null,
@@ -315,7 +331,8 @@ export default {
         this.owner ? (payload['owner'] = this.owner) : false
         this.organization ? (payload['organization'] = this.organization) : false
         this.advanced.badge_ids ? (payload['badge_id'] = this.advanced.badge_ids) : false
-
+        this.sort_criteria ? (payload['sort'] = this.sort_criteria): false
+        this.sort_type ? (payload['order'] = this.sort_type) :false
         this.$store.dispatch('artifacts/fetchArtifacts', payload)
       } 
       this.searchInterval = setTimeout(() => {
@@ -351,6 +368,18 @@ export default {
     },
     handleScroll() {
       this.showScrollToTop = window.scrollY
+    },
+    showOptions(val){
+        if (val != "None"){
+          this.sortEnabled = true
+          this.sort_criteria = val
+        }
+        else{
+          this.sortEnabled = false
+        }
+    },
+    setSortType(val){
+      this.sort_type = val
     }
   },
   watch: {


### PR DESCRIPTION
I have created a dropdown list for sorting results. The dropdown list has three options: date, views, and rating. I have also added an option None to allow users to cancer sort when trying to search again. I have added a couple of radio buttons to specify which way it should be sorted ascending or descending. The radio buttons will only be visible if the user has selected sort criteria. If the user selects None, radio buttons will not be displayed. This addresses the frontend side of the sort results feature: https://github.com/ITI/searcch/issues/159